### PR TITLE
fix abi version (16) and abi version test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,10 @@ build:
 outputs:
   - name: nanobind-abi
     version: {{ abi_version }}
+    requirements:
+      run_constrained:
+        # conflict with nanobind releases before the nanobind-abi package was added
+        - nanobind >=2.4
     build:
       noarch: generic
       run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.8.0" %}
 {% set robin_map_commit = "188c45569cc2a5dd768077c193830b51d33a5020" %}
-{% set abi_version = 15 %}
+{% set abi_version = 16 %}
 
 package:
   name: nanobind-split
@@ -14,7 +14,7 @@ source:
     folder: ext/robin_map
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: nanobind-abi
@@ -25,10 +25,10 @@ outputs:
         - nanobind-abi =={{ abi_version }}
     test:
       source_files:
-        - src/nb_internals.cpp
+        - src/nb_abi.h
       commands:
         # make sure the internals version matches the package version
-        - if [ $(grep "define NB_INTERNALS_VERSION" src/nb_internals.cpp | grep -E -o '[0-9]+') != "{{ abi_version }}" ]; then exit 1; fi
+        - if [[ $(grep "define NB_INTERNALS_VERSION" src/nb_abi.h | grep -E -o '[0-9]+') != "{{ abi_version }}" ]]; then exit 1; fi
 
   - name: nanobind
     build:


### PR DESCRIPTION
test was passing despite being incorrect, it should no longer do that

will need a repodata patch on releases 2.6-2.8 to fix the abi version to 16