### PR TITLE
Bump nanobind-abi to 20 for nanobind 2.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.13.0" %}
 {% set robin_map_commit = "188c45569cc2a5dd768077c193830b51d33a5020" %}
-{% set abi_version = 19 %}
+{% set abi_version = 20 %}
 
 package:
   name: nanobind-split


### PR DESCRIPTION
## Problem

CI is currently red on `main`. The v2.13.0 update (#39) bumped the package version but left the recipe's \`abi_version\` pin at 19.